### PR TITLE
HOTFIX: Fix for CHARGE, DISCHARGE, and explicit current states

### DIFF
--- a/src/evse_controller/drivers/EvseController.py
+++ b/src/evse_controller/drivers/EvseController.py
@@ -838,12 +838,6 @@ class EvseController(PowerMonitorObserver):
                 if (self.evseCurrent != desiredEvseCurrent):
                     info(f"ADJUST Changing from {self.evseCurrent} A to {desiredEvseCurrent} A")
                 self._setCurrent(desiredEvseCurrent)
-            elif self.state == ControlState.FREERUN:
-                # In FREERUN state, don't log ADJUST message or set current
-                debug("Skipping current adjustment in FREERUN state")
-            elif self._ocpp_mode_active:
-                # In OCPP mode, don't log ADJUST message or set current
-                debug("Skipping current adjustment in OCPP mode")
 
     def setControlState(self, state: ControlState):
         """Set the control state and log the transition."""

--- a/src/evse_controller/smart_evse_controller.py
+++ b/src/evse_controller/smart_evse_controller.py
@@ -398,8 +398,10 @@ def main():
                     evseController.setControlState(ControlState.DORMANT)
                 elif execState == ExecState.CHARGE:
                     evseController.setControlState(ControlState.CHARGE)
+                    evseController.setChargeCurrentRange(config.WALLBOX_MAX_CHARGE_CURRENT, config.WALLBOX_MAX_CHARGE_CURRENT)
                 elif execState == ExecState.DISCHARGE:
                     evseController.setControlState(ControlState.DISCHARGE)
+                    evseController.setDischargeCurrentRange(config.WALLBOX_MAX_DISCHARGE_CURRENT, config.WALLBOX_MAX_DISCHARGE_CURRENT)
 
             if execState == ExecState.SMART:
                 dayMinute = now.tm_hour * 60 + now.tm_min

--- a/src/evse_controller/smart_evse_controller.py
+++ b/src/evse_controller/smart_evse_controller.py
@@ -350,7 +350,8 @@ def main():
                             evseController.setChargeCurrentRange(currentAmps, currentAmps)
                         elif currentAmps < 0:
                             evseController.setControlState(ControlState.DISCHARGE)
-                            evseController.setDischargeCurrentRange(currentAmps, currentAmps)
+                            # setDischargeCurrentRange takes positive current values
+                            evseController.setDischargeCurrentRange(-currentAmps, -currentAmps)
                         else:
                             evseController.setControlState(ControlState.DORMANT)
                         execState = ExecState.FIXED

--- a/tests/test_octopus_ioctgo_tariff.py
+++ b/tests/test_octopus_ioctgo_tariff.py
@@ -59,13 +59,13 @@ def test_control_state_off_peak(intgo_tariff):
     assert state == ControlState.CHARGE
     assert min_current is None
     assert max_current is None
-    assert "IOCTGO Night rate: charge at max rate" in message
+    assert "IOCTGO Cheap rate: charge at max rate" in message
 
     # Test with battery full
     state = create_test_state(config.MAX_CHARGE_PERCENT)
     state, min_current, max_current, message = intgo_tariff.get_control_state(state, 1420)  # 23:40
     assert state == ControlState.DORMANT
-    assert "IOCTGO Night rate: SoC max" in message
+    assert "IOCTGO Cheap rate: SoC max" in message
 
 def test_control_state_low_battery(intgo_tariff):
     """Test behavior with low battery level during peak period"""
@@ -243,4 +243,4 @@ def test_control_state_evening_discharge_edge_cases(intgo_tariff):
     # At start of cheap rate
     control_state, min_current, max_current, message = intgo_tariff.get_control_state(state, 1410)  # 23:30
     assert control_state == ControlState.CHARGE
-    assert "Night rate" in message
+    assert "Cheap rate" in message


### PR DESCRIPTION
I don't know when this happened but CHARGE and DISCHARGE are meant to set the maximum charge and discharge rate, and they were not doing that. Also discharging a specific amount of current was not setting the right amount of current properly. This emergency fix sorts out these problems. It also modifies the logging a bit but that's not really important for this hotfix merge to main.