### PR TITLE
51 ioctgo mode turn off ocpp isnt reliable

### DIFF
--- a/QWEN.md
+++ b/QWEN.md
@@ -16,6 +16,14 @@
   - EVSE hardware interface (`drivers/evse/`)
   - Tariff management (`tariffs/`)
 
+## Tariff Management System
+
+### TariffManager Implementation
+- The TariffManager creates tariff instances only when needed rather than keeping all instances in memory
+- Stores tariff classes in the `tariff_classes` attribute to instantiate on demand
+- Each tariff is properly initialized when instantiated, ensuring correct state synchronization
+- Initialization now happens in each tariff's constructor rather than through a separate `initialize_tariff()` method
+
 ## Scheduling System
 
 ### Schedulable States

--- a/QWEN.md
+++ b/QWEN.md
@@ -24,6 +24,15 @@
 - Each tariff is properly initialized when instantiated, ensuring correct state synchronization
 - Initialization now happens in each tariff's constructor rather than through a separate `initialize_tariff()` method
 
+## OCPP Management System
+
+### OCPPManager Implementation
+- The new `OCPPManager` handles all OCPP state discovery and management asynchronously
+- Implements rate limiting with exponential backoff and retry logic
+- Uses the existing event bus system to communicate state changes
+- Properly handles credential validation with graceful degradation when credentials are missing
+- Decouples OCPP state management from the rest of the system using an asynchronous approach
+
 ## Scheduling System
 
 ### Schedulable States

--- a/src/evse_controller/drivers/EvseController.py
+++ b/src/evse_controller/drivers/EvseController.py
@@ -206,8 +206,8 @@ class EvseController(PowerMonitorObserver):
         
         # Subscribe to OCPP enable/disable request events
         self._event_bus = EventBus()
-        self._event_bus.subscribe(EventType.OCPP_ENABLE_REQUESTED, self._handle_ocpp_enable_request)
-        self._event_bus.subscribe(EventType.OCPP_DISABLE_REQUESTED, self._handle_ocpp_disable_request)
+        # Do not subscribe to OCPP request events as they are now handled by the OCPPManager
+        # The EvseController will only publish actual state changes
 
     def _update_channel_metadata(self):
         """Update the channel metadata in the history dictionary.
@@ -1043,33 +1043,7 @@ class EvseController(PowerMonitorObserver):
             error(f"Failed to disable OCPP: {e}")
             return False
 
-    def _handle_ocpp_enable_request(self, request_data) -> None:
-        """Handle OCPP enable request event from the event bus.
-        
-        Args:
-            request_data: Data associated with the request (can be timestamp or more structured data)
-        """
-        # Use the controller's main enableOcpp method to avoid code duplication
-        # and ensure proper event publishing
-        success = self.enableOcpp()
-        if success:
-            info("OCPP enabled successfully via enable request")
-        else:
-            error("Failed to enable OCPP via enable request")
 
-    def _handle_ocpp_disable_request(self, request_data) -> None:
-        """Handle OCPP disable request event from the event bus.
-        
-        Args:
-            request_data: Data associated with the request (can be timestamp or more structured data)
-        """
-        # Use the controller's main disableOcpp method to avoid code duplication
-        # and ensure proper event publishing
-        success = self.disableOcpp()
-        if success:
-            info("OCPP disabled successfully via disable request")
-        else:
-            error("Failed to disable OCPP via disable request")
 
     def stop(self):
         """Stop the controller and cleanup resources."""

--- a/src/evse_controller/drivers/evse/event_bus.py
+++ b/src/evse_controller/drivers/evse/event_bus.py
@@ -9,8 +9,6 @@ from enum import Enum
 class EventType(Enum):
     OCPP_ENABLED = "ocpp_enabled"
     OCPP_DISABLED = "ocpp_disabled"
-    OCPP_ENABLE_REQUESTED = "ocpp_enable_requested"
-    OCPP_DISABLE_REQUESTED = "ocpp_disable_requested"
     # Other event types can be added here
 
 

--- a/src/evse_controller/drivers/evse/ocpp_manager.py
+++ b/src/evse_controller/drivers/evse/ocpp_manager.py
@@ -1,0 +1,261 @@
+"""
+Asynchronous OCPP Manager for handling OCPP state discovery and management
+with rate limiting and retry logic.
+"""
+import threading
+import queue
+import time
+import random
+from enum import Enum
+from typing import Dict, Any, Optional
+
+from evse_controller.drivers.evse.event_bus import EventBus, EventType
+from evse_controller.utils.config import config
+from evse_controller.drivers.evse.wallbox.wallbox_api_with_ocpp import WallboxAPIWithOCPP
+from evse_controller.utils.logging_config import debug, info, warning, error
+
+
+class OCPPCommand(Enum):
+    """Commands that can be sent to the OCPP manager"""
+    GET_STATE = "get_state"
+    SET_ENABLED = "set_enabled"
+    SET_DISABLED = "set_disabled"
+
+
+class OCPPManager:
+    """
+    Asynchronous manager for OCPP state discovery and management.
+    Handles rate limiting, retries with exponential backoff, and uses event bus
+    for state change notifications.
+    """
+    
+    _instance = None
+    _lock = threading.Lock()
+    
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if hasattr(self, '_initialized'):
+            return
+            
+        self.state = None  # Current known OCPP state (True=enabled, False=disabled, None=unknown)
+        self.event_bus = EventBus()
+        self.request_queue = queue.Queue()
+        self.retry_queue = queue.PriorityQueue()  # (retry_time, job)
+        self._stop_event = threading.Event()
+        self._worker_thread = None
+        self._retry_thread = None
+        self._api_client = None
+        self._initialized = True
+        
+        # Configuration for retries
+        self.max_retries = 5
+        self.base_delay = 5  # seconds
+        self.max_delay = 300  # 5 minutes
+
+    def start(self):
+        """Start the OCPP manager worker threads"""
+        if self._worker_thread is None or not self._worker_thread.is_alive():
+            self._worker_thread = threading.Thread(target=self._process_requests, daemon=True)
+            self._worker_thread.start()
+        
+        if self._retry_thread is None or not self._retry_thread.is_alive():
+            self._retry_thread = threading.Thread(target=self._process_retries, daemon=True)
+            self._retry_thread.start()
+
+    def stop(self):
+        """Stop the OCPP manager worker threads"""
+        self._stop_event.set()
+        # Add sentinel values to wake up threads
+        self.request_queue.put(None)
+        
+    def get_state(self) -> Optional[bool]:
+        """Get the current known OCPP state"""
+        return self.state
+
+    def request_state_discovery(self):
+        """Asynchronously request current OCPP state"""
+        job = {
+            'command': OCPPCommand.GET_STATE,
+            'timestamp': time.time(),
+            'attempts': 0
+        }
+        self.request_queue.put(job)
+
+    def set_state(self, target_state: bool):
+        """Request to set OCPP to a specific state"""
+        command = OCPPCommand.SET_ENABLED if target_state else OCPPCommand.SET_DISABLED
+        job = {
+            'command': command,
+            'target_state': target_state,
+            'timestamp': time.time(),
+            'attempts': 0
+        }
+        self.request_queue.put(job)
+
+    def _has_credentials(self) -> bool:
+        """Check if required credentials are available"""
+        return all([
+            config.WALLBOX_USERNAME,
+            config.WALLBOX_PASSWORD,
+            config.WALLBOX_SERIAL
+        ])
+
+    def _get_api_client(self):
+        """Get or create API client with credentials"""
+        if not self._has_credentials():
+            return None
+            
+        if self._api_client is None:
+            try:
+                self._api_client = WallboxAPIWithOCPP(
+                    config.WALLBOX_USERNAME,
+                    config.WALLBOX_PASSWORD
+                )
+            except Exception as e:
+                error(f"OCPP Manager: Failed to create API client: {e}")
+                return None
+                
+        return self._api_client
+
+    def _execute_request(self, job: Dict[str, Any]):
+        """Execute a single OCPP request"""
+        try:
+            api_client = self._get_api_client()
+            if not api_client:
+                # If no credentials, assume OCPP is off
+                return {'status_code': None, 'successful': True, 'ocpp_enabled': False}
+                
+            if job['command'] == OCPPCommand.GET_STATE:
+                ocpp_enabled = api_client.is_ocpp_enabled(config.WALLBOX_SERIAL)
+                return {'status_code': 200, 'successful': True, 'ocpp_enabled': ocpp_enabled}
+                
+            elif job['command'] == OCPPCommand.SET_ENABLED:
+                api_client.set_ocpp_enabled(config.WALLBOX_SERIAL, True)
+                return {'status_code': 200, 'successful': True, 'ocpp_enabled': True}
+                
+            elif job['command'] == OCPPCommand.SET_DISABLED:
+                api_client.set_ocpp_enabled(config.WALLBOX_SERIAL, False)
+                return {'status_code': 200, 'successful': True, 'ocpp_enabled': False}
+                
+        except Exception as e:
+            # Check if it's a rate limit error (429)
+            if "429" in str(e) or "rate" in str(e).lower():
+                return {'status_code': 429, 'successful': False, 'error': str(e)}
+            else:
+                return {'status_code': None, 'successful': False, 'error': str(e)}
+
+    def _calculate_backoff_delay(self, attempt_count: int) -> float:
+        """Calculate delay with exponential backoff and jitter"""
+        # Exponential backoff: base_delay * (2^(attempt-1))
+        delay = min(self.base_delay * (2 ** (attempt_count-1)), self.max_delay)
+        # Add jitter to smooth out thundering herd
+        jitter = random.uniform(0.8, 1.2)
+        # Ensure the result doesn't exceed the max_delay even with jitter
+        return min(delay * jitter, self.max_delay)
+
+    def _process_requests(self):
+        """Main processing loop for handling OCPP requests"""
+        while not self._stop_event.is_set():
+            try:
+                # Get job from queue with timeout to allow checking stop_event
+                job = self.request_queue.get(timeout=1)
+                
+                # Check if it's a sentinel value to stop
+                if job is None:
+                    break
+                    
+                result = self._execute_request(job)
+                
+                if result['successful']:
+                    # Handle successful response
+                    self._handle_successful_response(job, result)
+                else:
+                    # Handle failure with retry logic
+                    job['attempts'] += 1
+                    if job['attempts'] < self.max_retries:
+                        delay = self._calculate_backoff_delay(job['attempts'])
+                        retry_time = time.time() + delay
+                        # Add to retry queue with priority based on retry time
+                        self.retry_queue.put((retry_time, job))
+                        info(f"OCPP Manager: Request failed, scheduled retry in {delay:.1f}s (attempt {job['attempts']}/{self.max_retries})")
+                    else:
+                        # Max retries reached - log error and publish current state if available
+                        error(f"OCPP Manager: Request failed after {self.max_retries} attempts: {result.get('error', 'Unknown error')}")
+                        self._handle_persistent_error(job)
+                        
+            except queue.Empty:
+                continue  # Continue loop to check for stop_event
+            except Exception as e:
+                error(f"OCPP Manager: Error processing request: {e}")
+
+    def _process_retries(self):
+        """Process retry queue"""
+        while not self._stop_event.is_set():
+            try:
+                if not self.retry_queue.empty():
+                    retry_time, job = self.retry_queue.queue[0]
+                    if time.time() >= retry_time:
+                        # Pop the job from the queue and put it back to the main queue
+                        self.retry_queue.get()  # Remove the job
+                        self.request_queue.put(job)
+                else:
+                    # Sleep briefly if no retries are pending
+                    time.sleep(0.1)
+            except Exception as e:
+                error(f"OCPP Manager: Error in retry processing: {e}")
+                time.sleep(1)
+
+    def _handle_successful_response(self, job: Dict[str, Any], result: Dict[str, Any]):
+        """Handle successful API response"""
+        if job['command'] == OCPPCommand.GET_STATE:
+            new_state = result.get('ocpp_enabled', False)
+            old_state = self.state
+            self.state = new_state
+            
+            # Publish appropriate state event
+            event_type = EventType.OCPP_ENABLED if new_state else EventType.OCPP_DISABLED
+            self.event_bus.publish(event_type, time.time())
+            debug(f"OCPP Manager: State discovery - OCPP is {'enabled' if new_state else 'disabled'}")
+
+        elif job['command'] in [OCPPCommand.SET_ENABLED, OCPPCommand.SET_DISABLED]:
+            target_state = job.get('target_state', self.state)
+            old_state = self.state
+            self.state = target_state
+            
+            # Publish state change event
+            event_type = EventType.OCPP_ENABLED if target_state else EventType.OCPP_DISABLED
+            self.event_bus.publish(event_type, time.time())
+            info(f"OCPP Manager: State changed - OCPP is now {'enabled' if target_state else 'disabled'}")
+
+    def _handle_persistent_error(self, job: Dict[str, Any]):
+        """Handle error when max retries are exceeded"""
+        # If we can't determine the state, assume it's unchanged but log the issue
+        if job['command'] == OCPPCommand.GET_STATE:
+            warning(f"OCPP Manager: Could not determine OCPP state after retries, keeping current state: {self.state}")
+        else:
+            # For enable/disable commands, we can't confirm the state change
+            event_type = EventType.OCPP_ENABLED if self.state else EventType.OCPP_DISABLED
+            self.event_bus.publish(event_type, time.time())
+            warning(f"OCPP Manager: Could not {job['command'].value.replace('set_', '')} OCPP after retries")
+            
+    def initialize(self):
+        """Initialize the OCPP manager and start threads"""
+        self.start()
+        # If we have credentials, request initial state discovery
+        if self._has_credentials():
+            self.request_state_discovery()
+        else:
+            # If no credentials, assume OCPP is off
+            self.state = False
+            self.event_bus.publish(EventType.OCPP_DISABLED, time.time())
+            warning("OCPP Manager: Missing credentials, assuming OCPP is disabled")
+
+
+# Global instance for easy access
+ocpp_manager = OCPPManager()

--- a/src/evse_controller/drivers/evse/ocpp_manager.py
+++ b/src/evse_controller/drivers/evse/ocpp_manager.py
@@ -14,6 +14,7 @@ from evse_controller.drivers.evse.event_bus import EventBus, EventType
 from evse_controller.utils.config import config
 from evse_controller.drivers.evse.wallbox.wallbox_api_with_ocpp import WallboxAPIWithOCPP
 from evse_controller.utils.logging_config import debug, info, warning, error
+from evse_controller.utils.redaction import redact_sensitive_data
 
 
 class OCPPCommand(Enum):
@@ -139,14 +140,14 @@ class OCPPManager:
             if job['command'] == OCPPCommand.GET_STATE:
                 debug(f"OCPP Manager: Calling is_ocpp_enabled for serial {config.WALLBOX_SERIAL}")
                 ocpp_enabled = api_client.is_ocpp_enabled(config.WALLBOX_SERIAL)
-                debug(f"OCPP Manager: is_ocpp_enabled returned: {ocpp_enabled}")
+                debug(f"OCPP Manager: is_ocpp_enabled returned: {redact_sensitive_data(ocpp_enabled)}")
                 return {'status_code': 200, 'successful': True, 'ocpp_enabled': ocpp_enabled}
                 
             elif job['command'] == OCPPCommand.SET_ENABLED:
                 debug(f"OCPP Manager: Calling enable_ocpp for serial {config.WALLBOX_SERIAL}")
                 try:
                     result = api_client.enable_ocpp(config.WALLBOX_SERIAL)
-                    debug(f"OCPP Manager: enable_ocpp returned: {result}")
+                    debug(f"OCPP Manager: enable_ocpp returned: {redact_sensitive_data(result)}")
                     debug(f"OCPP Manager: enable_ocpp result type: {type(result)}")
                     # Check if result indicates success
                     if isinstance(result, dict):
@@ -171,7 +172,7 @@ class OCPPManager:
                 debug(f"OCPP Manager: Calling disable_ocpp for serial {config.WALLBOX_SERIAL}")
                 try:
                     result = api_client.disable_ocpp(config.WALLBOX_SERIAL)
-                    debug(f"OCPP Manager: disable_ocpp returned: {result}")
+                    debug(f"OCPP Manager: disable_ocpp returned: {redact_sensitive_data(result)}")
                     debug(f"OCPP Manager: disable_ocpp result type: {type(result)}")
                     # Check if result indicates success
                     if isinstance(result, dict):

--- a/src/evse_controller/drivers/evse/wallbox/wallbox_api_with_ocpp.py
+++ b/src/evse_controller/drivers/evse/wallbox/wallbox_api_with_ocpp.py
@@ -6,6 +6,7 @@ import requests
 import time
 from wallbox import Wallbox
 from evse_controller.utils.logging_config import debug, info, warning, error
+from evse_controller.utils.redaction import redact_sensitive_data
 
 
 class WallboxAPIWithOCPP(Wallbox):
@@ -140,6 +141,8 @@ class WallboxAPIWithOCPP(Wallbox):
             response.raise_for_status()
             result = response.json()
             debug(f"OCPP API: Successfully retrieved status for charger {charger_id}: type={result.get('type')}")
+            # Log the full result with sensitive data redacted
+            debug(f"OCPP API: Full status result (redacted): {redact_sensitive_data(result)}")
             
             # Cache the result
             self._ocpp_status_cache[cache_key] = result
@@ -226,6 +229,8 @@ class WallboxAPIWithOCPP(Wallbox):
             response.raise_for_status()
             result = response.json()
             debug(f"OCPP API: Successfully updated OCPP configuration for charger {charger_id}")
+            # Log the full result with sensitive data redacted
+            debug(f"OCPP API: Configuration update result (redacted): {redact_sensitive_data(result)}")
             return result
         except requests.exceptions.HTTPError as err:
             error(f"OCPP API: HTTP error {err} when updating configuration for charger {charger_id}")

--- a/src/evse_controller/drivers/evse/wallbox/wallbox_api_with_ocpp.py
+++ b/src/evse_controller/drivers/evse/wallbox/wallbox_api_with_ocpp.py
@@ -3,7 +3,9 @@ Extended Wallbox class with OCPP endpoint support
 """
 import json
 import requests
+import time
 from wallbox import Wallbox
+from evse_controller.utils.logging_config import debug, info, warning, error
 
 
 class WallboxAPIWithOCPP(Wallbox):
@@ -115,30 +117,44 @@ class WallboxAPIWithOCPP(Wallbox):
         
         # Check if we have a valid cached response
         if self._is_cache_valid(cache_key):
+            debug(f"OCPP API: Returning cached status for charger {charger_id}")
             return self._ocpp_status_cache[cache_key]
         
         # Ensure we have a valid authentication token
+        debug(f"OCPP API: Authenticating for charger {charger_id}")
         self.authenticate()
         
         try:
+            debug(f"OCPP API: Making request to get OCPP status for charger {charger_id}")
             response = requests.get(
                 f"{self.baseUrl}v3/chargers/{charger_id}/ocpp-configuration",
                 headers=self.headers,
                 timeout=self._requestGetTimeout
             )
+            debug(f"OCPP API: Response status {response.status_code} for charger {charger_id}")
+            
+            if response.status_code == 429:
+                warning(f"OCPP API: Rate limited (429) when getting status for charger {charger_id}")
+                raise requests.exceptions.HTTPError(f"Rate limited: {response.status_code}")
+            
             response.raise_for_status()
             result = response.json()
+            debug(f"OCPP API: Successfully retrieved status for charger {charger_id}: type={result.get('type')}")
             
             # Cache the result
-            import time
             self._ocpp_status_cache[cache_key] = result
             self._ocpp_status_cache_timestamp[cache_key] = time.time()
             
             return result
         except requests.exceptions.HTTPError as err:
             # Clear the cache if request fails to avoid using stale data
-            self._clear_cache(charger_id)
+            error(f"OCPP API: HTTP error {err} when getting status for charger {charger_id}")
+            self._clear_status_cache(charger_id)
             raise err
+        except Exception as e:
+            error(f"OCPP API: Unexpected error {e} when getting status for charger {charger_id}")
+            self._clear_status_cache(charger_id)
+            raise e
     
     def is_ocpp_enabled(self, charger_id):
         """
@@ -153,8 +169,11 @@ class WallboxAPIWithOCPP(Wallbox):
         Raises:
             requests.exceptions.HTTPError: If the API request fails
         """
+        debug(f"OCPP API: Checking if OCPP is enabled for charger {charger_id}")
         status = self.get_ocpp_status(charger_id)
-        return status.get("type") == "ocpp"
+        is_enabled = status.get("type") == "ocpp"
+        debug(f"OCPP API: OCPP is {'enabled' if is_enabled else 'disabled'} for charger {charger_id}")
+        return is_enabled
     
     def _send_ocpp_configuration(self, charger_id, address=None, charge_point_identity=None, password=None, ocpp_type="ocpp"):
         """
@@ -174,6 +193,7 @@ class WallboxAPIWithOCPP(Wallbox):
             requests.exceptions.HTTPError: If the API request fails
         """
         # Ensure we have a valid authentication token
+        debug(f"OCPP API: Authenticating for OCPP configuration update for charger {charger_id}")
         self.authenticate()
         
         # Prepare the request data
@@ -189,6 +209,7 @@ class WallboxAPIWithOCPP(Wallbox):
         if password is not None:
             data["password"] = password
             
+        debug(f"OCPP API: Sending OCPP configuration for charger {charger_id}, type={ocpp_type}")
         try:
             response = requests.post(
                 f"{self.baseUrl}v3/chargers/{charger_id}/ocpp-configuration",
@@ -196,10 +217,22 @@ class WallboxAPIWithOCPP(Wallbox):
                 json=data,
                 timeout=self._requestGetTimeout
             )
+            debug(f"OCPP API: Configuration update response status {response.status_code} for charger {charger_id}")
+            
+            if response.status_code == 429:
+                warning(f"OCPP API: Rate limited (429) when updating configuration for charger {charger_id}")
+                raise requests.exceptions.HTTPError(f"Rate limited: {response.status_code}")
+            
             response.raise_for_status()
-            return response.json()
+            result = response.json()
+            debug(f"OCPP API: Successfully updated OCPP configuration for charger {charger_id}")
+            return result
         except requests.exceptions.HTTPError as err:
+            error(f"OCPP API: HTTP error {err} when updating configuration for charger {charger_id}")
             raise err
+        except Exception as e:
+            error(f"OCPP API: Unexpected error {e} when updating configuration for charger {charger_id}")
+            raise e
     
     def enable_ocpp(self, charger_id):
         """
@@ -214,6 +247,7 @@ class WallboxAPIWithOCPP(Wallbox):
         Raises:
             requests.exceptions.HTTPError: If the API request fails
         """
+        info(f"OCPP API: Enabling OCPP mode for charger {charger_id}")
         # Get the OCPP configuration parameters (credentials that rarely change)
         config_params = self._get_ocpp_config_params(charger_id)
         
@@ -228,6 +262,7 @@ class WallboxAPIWithOCPP(Wallbox):
         
         # Clear the status cache after successful update (config cache is kept)
         self._clear_status_cache(charger_id)
+        info(f"OCPP API: Successfully enabled OCPP mode for charger {charger_id}")
         
         return result
     
@@ -244,6 +279,7 @@ class WallboxAPIWithOCPP(Wallbox):
         Raises:
             requests.exceptions.HTTPError: If the API request fails
         """
+        info(f"OCPP API: Disabling OCPP mode for charger {charger_id}")
         # Get the OCPP configuration parameters (credentials that rarely change)
         config_params = self._get_ocpp_config_params(charger_id)
         
@@ -258,6 +294,7 @@ class WallboxAPIWithOCPP(Wallbox):
         
         # Clear the status cache after successful update (config cache is kept)
         self._clear_status_cache(charger_id)
+        info(f"OCPP API: Successfully disabled OCPP mode for charger {charger_id}")
         
         return result
 

--- a/src/evse_controller/smart_evse_controller.py
+++ b/src/evse_controller/smart_evse_controller.py
@@ -103,7 +103,7 @@ else:
     # For tariff-based startup states
     execState = ExecState.SMART
     # Set the appropriate tariff based on startup state if it's a valid tariff
-    if config.STARTUP_STATE in tariffManager.tariffs:
+    if config.STARTUP_STATE in tariffManager.tariff_classes:
         tariffManager.set_tariff(config.STARTUP_STATE)
 scheduler = Scheduler()
 

--- a/src/evse_controller/tariffs/manager.py
+++ b/src/evse_controller/tariffs/manager.py
@@ -9,24 +9,26 @@ from evse_controller.utils.logging_config import debug
 
 class TariffManager:
     def __init__(self):
-        self.tariffs = {
-            "OCTGO": OctopusGoTariff(),
-            "IOCTGO": IntelligentOctopusGoTariff(),
-            "COSY": CosyOctopusTariff(),
-            "FLUX": OctopusFluxTariff()
+        # Store tariff classes instead of instances to instantiate only when needed
+        self.tariff_classes = {
+            "OCTGO": OctopusGoTariff,
+            "IOCTGO": IntelligentOctopusGoTariff,
+            "COSY": CosyOctopusTariff,
+            "FLUX": OctopusFluxTariff
         }
         # Check if startup state is a tariff that exists in our tariffs dictionary
-        if config.STARTUP_STATE in self.tariffs:
-            self.current_tariff = self.tariffs[config.STARTUP_STATE]
+        if config.STARTUP_STATE in self.tariff_classes:
+            # Instantiate the tariff for the startup state
+            self.current_tariff = self.tariff_classes[config.STARTUP_STATE]()
         else:
             # For non-tariff startup states (like FREERUN), set to None
             self.current_tariff = None
 
     def set_tariff(self, tariff_name):
-        if tariff_name in self.tariffs:
-            self.current_tariff = self.tariffs[tariff_name]
-            # Initialize the newly selected tariff
-            self.current_tariff.initialize_tariff()
+        if tariff_name in self.tariff_classes:
+            # Create a new instance of the requested tariff
+            self.current_tariff = self.tariff_classes[tariff_name]()
+            # The initialization now happens in the tariff's constructor
             return True
         return False
 

--- a/src/evse_controller/tariffs/octopus/ioctgo.py
+++ b/src/evse_controller/tariffs/octopus/ioctgo.py
@@ -513,14 +513,14 @@ class IntelligentOctopusGoTariff(Tariff):
         mins = minutes % 60
         return f"{hours:02d}:{mins:02d}"
 
-    def _handle_ocpp_enabled(self) -> None:
+    def _handle_ocpp_enabled(self, event_data=None) -> None:
         """Handle OCPP enabled event from the event bus."""
         with self._state_lock:
             old_state = self._ocpp_enabled
             self._ocpp_enabled = True
             info(f"IOCTGO OCPP state changed to enabled")
 
-    def _handle_ocpp_disabled(self) -> None:
+    def _handle_ocpp_disabled(self, event_data=None) -> None:
         """Handle OCPP disabled event from the event bus."""
         with self._state_lock:
             old_state = self._ocpp_enabled

--- a/src/evse_controller/tariffs/octopus/ioctgo.py
+++ b/src/evse_controller/tariffs/octopus/ioctgo.py
@@ -448,6 +448,8 @@ class IntelligentOctopusGoTariff(Tariff):
             
             # Check if we should disable OCPP
             should_disable = self.should_disable_ocpp(state, dayMinute)
+
+            debug(f"IOCTGO OCPP:{is_ocpp_currently_enabled}, should_enable:{should_enable}, should_disable:{should_disable}")
             
             # Handle OCPP state changes by publishing events to the event bus
             if should_enable and not is_ocpp_currently_enabled:
@@ -491,6 +493,7 @@ class IntelligentOctopusGoTariff(Tariff):
                 if dayMinute < self._time_to_minutes("05:29"):
                     is_check_time = False
                 
+                debug(f"IOCTGO OCPP disable check, is_check_time:{is_check_time}")
                 if is_check_time:
                     info("IOCTGO Checking whether to disable OCPP state")
                     if (state.battery_level != -1 and 

--- a/src/evse_controller/tariffs/octopus/ioctgo.py
+++ b/src/evse_controller/tariffs/octopus/ioctgo.py
@@ -110,6 +110,9 @@ class IntelligentOctopusGoTariff(Tariff):
         
         # === END CONFIGURABLE PARAMETERS ===
         
+        # Initialize OCPP state when tariff is first instantiated
+        self._initialize_ocpp_state_internal()
+        
     def _time_to_minutes(self, time_str: str) -> int:
         """Convert time string in HH:MM format to minutes since midnight.
         
@@ -312,7 +315,7 @@ class IntelligentOctopusGoTariff(Tariff):
         if self.SMART_OCPP_OPERATION:
             self._manage_ocpp_state(state, dayMinute)
 
-    def initialize_ocpp_state(self):
+    def _initialize_ocpp_state_internal(self):
         """Initialize the OCPP state by checking the current state from the Wallbox API."""
         try:
             if not all([config.WALLBOX_USERNAME, config.WALLBOX_PASSWORD, config.WALLBOX_SERIAL]):
@@ -400,32 +403,7 @@ class IntelligentOctopusGoTariff(Tariff):
         
         return False
 
-    def initialize_tariff(self):
-        """Initialize IOCTGO tariff-specific state.
-        
-        This method is called when IOCTGO tariff is first selected to initialize
-        the OCPP state by checking the current state from the Wallbox API.
-        
-        Returns:
-            bool: True if initialization was successful
-        """
-        # Initialize OCPP state when tariff is first activated
-        success = self.initialize_ocpp_state()
-        
-        # If OCPP is already enabled when this tariff starts, set the default disable time
-        if success:
-            with self._state_lock:
-                ocpp_enabled = self._ocpp_enabled
-                if ocpp_enabled:
-                    # When OCPP is already active, set the default disable time to OCPP_DISABLE_TIME
-                    self._dynamic_ocpp_disable_time = self.OCPP_DISABLE_TIME
-                    info("IOCTGO Initialising - OCPP mode is enabled")
-                else:
-                    info("IOCTGO Initialising - OCPP mode is disabled")
-        else:
-            info("IOCTGO Initialising - could not determine OCPP state")
-        
-        return success
+
 
     def _manage_ocpp_state(self, state: EvseAsyncState, dayMinute: int):
         """Manage OCPP state by publishing events to the event bus.

--- a/src/evse_controller/utils/redaction.py
+++ b/src/evse_controller/utils/redaction.py
@@ -1,0 +1,27 @@
+"""
+Redaction utility functions for sensitive data
+"""
+
+
+def redact_sensitive_data(data):
+    """
+    Redact sensitive information from data structures before logging.
+    
+    Args:
+        data: The data to redact (dict, list, or other)
+        
+    Returns:
+        The data with sensitive fields redacted
+    """
+    if isinstance(data, dict):
+        redacted = {}
+        for key, value in data.items():
+            if key.lower() in ['password', 'chargepointidentity', 'charge_point_identity']:
+                redacted[key] = 'REDACTED'
+            else:
+                redacted[key] = redact_sensitive_data(value)
+        return redacted
+    elif isinstance(data, list):
+        return [redact_sensitive_data(item) for item in data]
+    else:
+        return data

--- a/tests/test_ioctgo_integration.py
+++ b/tests/test_ioctgo_integration.py
@@ -26,21 +26,13 @@ class TestIntelligentOctopusGoTariffIntegration(unittest.TestCase):
         self.mock_state = Mock(spec=EvseAsyncState)
         self.mock_state.battery_level = 50  # Default to 50% SoC
 
-    def test_initialize_tariff_sets_up_ocpp_correctly(self):
-        """Test that initialize_tariff properly sets up OCPP state tracking."""
-        # Initially OCPP should be uninitialized
-        self.assertIsNone(self.tariff._ocpp_enabled)
-        # Removed the once-per-day limit tracking
-        # self.assertIsNone(self.tariff._last_ocpp_disable_day)  # No longer used
-        
-        # Check new field
+    def test_constructor_initializes_ocpp_state_properly(self):
+        """Test that constructor properly sets up OCPP state tracking."""
+        # NOTE: Since initialization now happens in the constructor, 
+        # _ocpp_enabled will be set during setUp() based on the mock API call
+        # In a real environment it would check the current OCPP state
+        # For this test we focus on the dynamic disable time
         self.assertIsNone(self.tariff._dynamic_ocpp_disable_time)
-        
-        # After initialization, OCPP should be properly set up
-        with patch.object(self.tariff, 'initialize_ocpp_state', return_value=True):
-            self.tariff.initialize_tariff()
-            # The initialize_ocpp_state method should have been called
-            # and _ocpp_enabled should be set (True in this case)
 
     def test_dynamic_disable_time_allows_multiple_sessions(self):
         """Test that OCPP can be disabled and enabled multiple times using dynamic disable time."""

--- a/tests/test_ioctgo_ocpp.py
+++ b/tests/test_ioctgo_ocpp.py
@@ -164,12 +164,7 @@ class TestIntelligentOctopusGoOCPP(unittest.TestCase):
         result = self.tariff.should_disable_ocpp(self.mock_state, 721)  # 12:01
         self.assertTrue(result)
 
-    def test_initialize_tariff_calls_initialize_ocpp_state(self):
-        """Test that initialize_tariff calls initialize_ocpp_state."""
-        with patch.object(self.tariff, 'initialize_ocpp_state', return_value=True) as mock_init:
-            result = self.tariff.initialize_tariff()
-            mock_init.assert_called_once()
-            self.assertTrue(result)
+
 
     def test_unknown_battery_level_handled_correctly(self):
         """Test that unknown battery level (-1) is handled correctly."""

--- a/tests/test_ocpp_manager.py
+++ b/tests/test_ocpp_manager.py
@@ -45,15 +45,15 @@ class TestOCPPManager(TestCase):
 
     def test_calculate_backoff_delay_with_jitter(self):
         """Test exponential backoff calculation with jitter."""
-        # Test first retry (should be around base_delay=5 seconds)
+        # Test first retry (should be around base_delay=1 seconds)
         delay1 = self.ocpp_manager._calculate_backoff_delay(1)
-        self.assertGreaterEqual(delay1, 5 * 0.8)  # With 0.8 jitter
-        self.assertLessEqual(delay1, 5 * 1.2)    # With 1.2 jitter
+        self.assertGreaterEqual(delay1, 1 * 0.8)  # With 0.8 jitter
+        self.assertLessEqual(delay1, 1 * 1.2)    # With 1.2 jitter
         
-        # Test second retry (should be around 10 seconds)
+        # Test second retry (should be around 2 seconds)
         delay2 = self.ocpp_manager._calculate_backoff_delay(2)
-        self.assertGreaterEqual(delay2, 10 * 0.8)  # 5 * 2^1 with jitter
-        self.assertLessEqual(delay2, 10 * 1.2)
+        self.assertGreaterEqual(delay2, 2 * 0.8)  # 1 * 2^1 with jitter
+        self.assertLessEqual(delay2, 2 * 1.2)
 
     def test_calculate_backoff_delay_respects_max_delay(self):
         """Test that backoff delay respects the maximum delay."""

--- a/tests/test_ocpp_manager.py
+++ b/tests/test_ocpp_manager.py
@@ -1,0 +1,288 @@
+"""
+Unit tests for the OCPPManager class.
+"""
+import unittest
+from unittest.mock import Mock, patch, MagicMock
+from unittest import TestCase
+import time
+import threading
+from queue import Queue, Empty
+
+from evse_controller.drivers.evse.ocpp_manager import OCPPManager
+from evse_controller.drivers.evse.event_bus import EventType
+
+
+class TestOCPPManager(TestCase):
+    """Unit tests for OCPPManager functionality."""
+
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        # Ensure we get a fresh instance for each test
+        OCPPManager._instance = None
+        OCPPManager._lock = threading.Lock()
+        
+        self.ocpp_manager = OCPPManager()
+
+    def tearDown(self):
+        """Tear down test fixtures after each test method."""
+        # Stop the threads to prevent interference between tests
+        if hasattr(self.ocpp_manager, '_worker_thread') and self.ocpp_manager._worker_thread:
+            self.ocpp_manager._stop_event.set()
+            # Add a sentinel to wake up the queue if needed
+            try:
+                self.ocpp_manager.request_queue.put(None)
+            except:
+                pass
+
+    def test_singleton_pattern(self):
+        """Test that OCPPManager follows the singleton pattern."""
+        another_manager = OCPPManager()
+        self.assertIs(self.ocpp_manager, another_manager)
+
+    def test_initial_state_is_none(self):
+        """Test that initial OCPP state is None."""
+        self.assertIsNone(self.ocpp_manager.get_state())
+
+    def test_calculate_backoff_delay_with_jitter(self):
+        """Test exponential backoff calculation with jitter."""
+        # Test first retry (should be around base_delay=5 seconds)
+        delay1 = self.ocpp_manager._calculate_backoff_delay(1)
+        self.assertGreaterEqual(delay1, 5 * 0.8)  # With 0.8 jitter
+        self.assertLessEqual(delay1, 5 * 1.2)    # With 1.2 jitter
+        
+        # Test second retry (should be around 10 seconds)
+        delay2 = self.ocpp_manager._calculate_backoff_delay(2)
+        self.assertGreaterEqual(delay2, 10 * 0.8)  # 5 * 2^1 with jitter
+        self.assertLessEqual(delay2, 10 * 1.2)
+
+    def test_calculate_backoff_delay_respects_max_delay(self):
+        """Test that backoff delay respects the maximum delay."""
+        # Test with a high retry count that would exceed max_delay
+        # With max jitter (1.2), result could be slightly over the max_delay
+        delay = self.ocpp_manager._calculate_backoff_delay(10)  # Should result in 5 * 2^9 = 2560 seconds (42+ mins) 
+        self.assertLessEqual(delay, 300 * 1.2)  # max_delay is 300 seconds (5 minutes) with possible jitter
+
+    def test_async_operation_without_blocking(self):
+        """Test that operations can be added to queue without blocking."""
+        start_time = time.time()
+        
+        # Add multiple requests to the queue without starting the manager
+        # (this should not block)
+        for i in range(5):
+            self.ocpp_manager.set_state(i % 2 == 0)  # Alternate True/False
+        
+        # This should return immediately without waiting for all operations
+        elapsed = time.time() - start_time
+        self.assertLess(elapsed, 0.5)  # Should be very fast
+
+    @patch('evse_controller.drivers.evse.ocpp_manager.config')
+    def test_has_credentials_returns_true_with_valid_creds(self, mock_config):
+        """Test that has_credentials returns True when all credentials are present."""
+        # Mock config values
+        mock_config.WALLBOX_USERNAME = "test_user"
+        mock_config.WALLBOX_PASSWORD = "test_pass"
+        mock_config.WALLBOX_SERIAL = "test_serial"
+        
+        result = self.ocpp_manager._has_credentials()
+        self.assertTrue(result)
+
+    @patch('evse_controller.drivers.evse.ocpp_manager.config')
+    def test_has_credentials_returns_false_with_missing_creds(self, mock_config):
+        """Test that has_credentials returns False when credentials are missing."""
+        # Set up missing credentials
+        mock_config.WALLBOX_USERNAME = ""
+        mock_config.WALLBOX_PASSWORD = ""
+        mock_config.WALLBOX_SERIAL = ""
+        
+        result = self.ocpp_manager._has_credentials()
+        self.assertFalse(result)
+
+    def test_request_methods_add_to_queue(self):
+        """Test that request methods add jobs to the queue."""
+        # Test state discovery request
+        initial_queue_size = self.ocpp_manager.request_queue.qsize() if not self.ocpp_manager.request_queue.qsize() else 0
+        self.ocpp_manager.request_state_discovery()
+        after_discovery_size = self.ocpp_manager.request_queue.qsize()
+        
+        self.assertEqual(after_discovery_size, initial_queue_size + 1)
+        
+        # Test set state request
+        self.ocpp_manager.set_state(True)
+        after_set_state_size = self.ocpp_manager.request_queue.qsize()
+        
+        self.assertEqual(after_set_state_size, after_discovery_size + 1)
+
+    @patch('evse_controller.utils.config.config')
+    @patch('evse_controller.drivers.evse.ocpp_manager.WallboxAPIWithOCPP')
+    def test_initialize_with_credentials(self, mock_api_class, mock_config):
+        """Test initialization behavior when credentials are available."""
+        # Mock config values
+        mock_config.WALLBOX_USERNAME = "test_user"
+        mock_config.WALLBOX_PASSWORD = "test_pass"
+        mock_config.WALLBOX_SERIAL = "test_serial"
+        
+        # Mock API instance
+        mock_api_instance = Mock()
+        mock_api_class.return_value = mock_api_instance
+        
+        # Start the manager
+        self.ocpp_manager.start()
+        
+        # The initial discovery request should be added to the queue
+        time.sleep(0.05)  # Allow time for initialization
+        self.assertGreaterEqual(self.ocpp_manager.request_queue.qsize(), 0)
+
+    @patch('evse_controller.utils.config.config')
+    @patch('evse_controller.drivers.evse.ocpp_manager.WallboxAPIWithOCPP')
+    def test_initialize_without_credentials(self, mock_api_class, mock_config):
+        """Test initialization behavior when credentials are missing."""
+        # Set up missing credentials
+        mock_config.WALLBOX_USERNAME = ""
+        mock_config.WALLBOX_PASSWORD = ""
+        mock_config.WALLBOX_SERIAL = ""
+        
+        # Start the manager - should default to disabled state
+        self.ocpp_manager.start()
+        
+        # State should be False when no credentials
+        self.assertFalse(self.ocpp_manager.state)
+
+
+class TestOCPPManagerWithMocks(TestCase):
+    """Additional tests that properly mock the API client for async operations."""
+    
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        # Ensure we get a fresh instance for each test
+        OCPPManager._instance = None
+        OCPPManager._lock = threading.Lock()
+        
+        self.ocpp_manager = OCPPManager()
+
+        # Patch the API client to avoid making real calls
+        self.api_patcher = patch('evse_controller.drivers.evse.ocpp_manager.WallboxAPIWithOCPP')
+        self.mock_api_class = self.api_patcher.start()
+        self.mock_api_instance = Mock()
+        self.mock_api_class.return_value = self.mock_api_instance
+    
+    def tearDown(self):
+        """Tear down test fixtures after each test method."""
+        if hasattr(self, 'api_patcher'):
+            self.api_patcher.stop()
+        
+        # Stop the threads to prevent interference between tests
+        if hasattr(self.ocpp_manager, '_worker_thread') and self.ocpp_manager._worker_thread:
+            self.ocpp_manager._stop_event.set()
+            # Add a sentinel to wake up the queue if needed
+            try:
+                self.ocpp_manager.request_queue.put(None)
+            except:
+                pass
+
+    def test_execute_request_get_state(self):
+        """Test the _execute_request method for getting state."""
+        # Patch config and API client at the same time
+        with patch('evse_controller.drivers.evse.ocpp_manager.config') as mock_config:
+            # Mock config values
+            mock_config.WALLBOX_USERNAME = "test_user"
+            mock_config.WALLBOX_PASSWORD = "test_pass"
+            mock_config.WALLBOX_SERIAL = "test_serial"
+            
+            # Create a job to get state
+            from evse_controller.drivers.evse.ocpp_manager import OCPPCommand
+            job = {
+                'command': OCPPCommand.GET_STATE,
+                'timestamp': time.time(),
+                'attempts': 0
+            }
+            
+            # Set up the API instance mock to return True for OCPP enabled
+            self.mock_api_instance.is_ocpp_enabled.return_value = True
+            
+            # Execute the request
+            result = self.ocpp_manager._execute_request(job)
+            
+            # Verify API was called
+            self.mock_api_instance.is_ocpp_enabled.assert_called_once_with("test_serial")
+            # Verify result
+            self.assertTrue(result['successful'])
+            self.assertTrue(result['ocpp_enabled'])
+
+    def test_execute_request_set_enabled(self):
+        """Test the _execute_request method for enabling OCPP."""
+        # Patch config at the same time
+        with patch('evse_controller.drivers.evse.ocpp_manager.config') as mock_config:
+            # Mock config values
+            mock_config.WALLBOX_USERNAME = "test_user"
+            mock_config.WALLBOX_PASSWORD = "test_pass"
+            mock_config.WALLBOX_SERIAL = "test_serial"
+            
+            # Create a job to set state to enabled
+            from evse_controller.drivers.evse.ocpp_manager import OCPPCommand
+            job = {
+                'command': OCPPCommand.SET_ENABLED,
+                'target_state': True,
+                'timestamp': time.time(),
+                'attempts': 0
+            }
+            
+            # Execute the request
+            result = self.ocpp_manager._execute_request(job)
+            
+            # Verify API was called to enable OCPP
+            self.mock_api_instance.set_ocpp_enabled.assert_called_once_with("test_serial", True)
+            # Verify result
+            self.assertTrue(result['successful'])
+
+    def test_execute_request_set_disabled(self):
+        """Test the _execute_request method for disabling OCPP."""
+        # Patch config at the same time
+        with patch('evse_controller.drivers.evse.ocpp_manager.config') as mock_config:
+            # Mock config values
+            mock_config.WALLBOX_USERNAME = "test_user"
+            mock_config.WALLBOX_PASSWORD = "test_pass"
+            mock_config.WALLBOX_SERIAL = "test_serial"
+            
+            # Create a job to set state to disabled
+            from evse_controller.drivers.evse.ocpp_manager import OCPPCommand
+            job = {
+                'command': OCPPCommand.SET_DISABLED,
+                'target_state': False,
+                'timestamp': time.time(),
+                'attempts': 0
+            }
+            
+            # Execute the request
+            result = self.ocpp_manager._execute_request(job)
+            
+            # Verify API was called to disable OCPP
+            self.mock_api_instance.set_ocpp_enabled.assert_called_once_with("test_serial", False)
+            # Verify result
+            self.assertTrue(result['successful'])
+
+    @patch('evse_controller.utils.config.config')
+    def test_execute_request_without_credentials(self, mock_config):
+        """Test the _execute_request method when credentials are missing."""
+        # Set up missing credentials
+        mock_config.WALLBOX_USERNAME = ""
+        mock_config.WALLBOX_PASSWORD = ""
+        mock_config.WALLBOX_SERIAL = ""
+        
+        # Create a job to get state
+        from evse_controller.drivers.evse.ocpp_manager import OCPPCommand
+        job = {
+            'command': OCPPCommand.GET_STATE,
+            'timestamp': time.time(),
+            'attempts': 0
+        }
+        
+        # Execute the request
+        result = self.ocpp_manager._execute_request(job)
+        
+        # When no credentials, should return success with disabled state
+        self.assertTrue(result['successful'])
+        self.assertFalse(result['ocpp_enabled'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ocpp_manager.py
+++ b/tests/test_ocpp_manager.py
@@ -45,15 +45,15 @@ class TestOCPPManager(TestCase):
 
     def test_calculate_backoff_delay_with_jitter(self):
         """Test exponential backoff calculation with jitter."""
-        # Test first retry (should be around base_delay=1 seconds)
+        # Test first retry (should be around base_delay=5 seconds)
         delay1 = self.ocpp_manager._calculate_backoff_delay(1)
-        self.assertGreaterEqual(delay1, 1 * 0.8)  # With 0.8 jitter
-        self.assertLessEqual(delay1, 1 * 1.2)    # With 1.2 jitter
+        self.assertGreaterEqual(delay1, 5 * 0.8)  # With 0.8 jitter
+        self.assertLessEqual(delay1, 5 * 1.2)    # With 1.2 jitter
         
-        # Test second retry (should be around 2 seconds)
+        # Test second retry (should be around 10 seconds)
         delay2 = self.ocpp_manager._calculate_backoff_delay(2)
-        self.assertGreaterEqual(delay2, 2 * 0.8)  # 1 * 2^1 with jitter
-        self.assertLessEqual(delay2, 2 * 1.2)
+        self.assertGreaterEqual(delay2, 10 * 0.8)  # 5 * 2^1 with jitter
+        self.assertLessEqual(delay2, 10 * 1.2)
 
     def test_calculate_backoff_delay_respects_max_delay(self):
         """Test that backoff delay respects the maximum delay."""
@@ -226,11 +226,14 @@ class TestOCPPManagerWithMocks(TestCase):
                 'attempts': 0
             }
             
+            # Set up the API instance mock to return a successful result
+            self.mock_api_instance.enable_ocpp.return_value = {"type": "ocpp", "success": True}
+            
             # Execute the request
             result = self.ocpp_manager._execute_request(job)
             
             # Verify API was called to enable OCPP
-            self.mock_api_instance.set_ocpp_enabled.assert_called_once_with("test_serial", True)
+            self.mock_api_instance.enable_ocpp.assert_called_once_with("test_serial")
             # Verify result
             self.assertTrue(result['successful'])
 
@@ -252,11 +255,14 @@ class TestOCPPManagerWithMocks(TestCase):
                 'attempts': 0
             }
             
+            # Set up the API instance mock to return a successful result
+            self.mock_api_instance.disable_ocpp.return_value = {"type": "wallbox", "success": True}
+            
             # Execute the request
             result = self.ocpp_manager._execute_request(job)
             
             # Verify API was called to disable OCPP
-            self.mock_api_instance.set_ocpp_enabled.assert_called_once_with("test_serial", False)
+            self.mock_api_instance.disable_ocpp.assert_called_once_with("test_serial")
             # Verify result
             self.assertTrue(result['successful'])
 

--- a/tests/test_ocpp_redaction.py
+++ b/tests/test_ocpp_redaction.py
@@ -1,0 +1,127 @@
+import unittest
+from src.evse_controller.utils.redaction import redact_sensitive_data
+
+
+class TestOCPPRedaction(unittest.TestCase):
+    """Test cases for the redaction function in OCPP manager"""
+
+    def test_redact_sensitive_data_dict(self):
+        """Test redacting sensitive data from a dictionary"""
+        input_data = {
+            "type": "ocpp",
+            "address": "https://example.com",
+            "chargePointIdentity": "secret_identity",
+            "password": "secret_password",
+            "normal_field": "normal_value"
+        }
+        
+        expected = {
+            "type": "ocpp",
+            "address": "https://example.com",
+            "chargePointIdentity": "REDACTED",
+            "password": "REDACTED",
+            "normal_field": "normal_value"
+        }
+        
+        result = redact_sensitive_data(input_data)
+        self.assertEqual(result, expected)
+
+    def test_redact_sensitive_data_nested_dict(self):
+        """Test redacting sensitive data from nested dictionaries"""
+        input_data = {
+            "type": "ocpp",
+            "config": {
+                "chargePointIdentity": "nested_secret_identity",
+                "password": "nested_secret_password",
+                "other": "value"
+            },
+            "list_field": [
+                {"chargePointIdentity": "list_secret", "password": "list_password"},
+                {"normal": "data"}
+            ]
+        }
+        
+        expected = {
+            "type": "ocpp",
+            "config": {
+                "chargePointIdentity": "REDACTED",
+                "password": "REDACTED",
+                "other": "value"
+            },
+            "list_field": [
+                {"chargePointIdentity": "REDACTED", "password": "REDACTED"},
+                {"normal": "data"}
+            ]
+        }
+        
+        result = redact_sensitive_data(input_data)
+        self.assertEqual(result, expected)
+
+    def test_redact_sensitive_data_list(self):
+        """Test redacting sensitive data from a list"""
+        input_data = [
+            {"chargePointIdentity": "secret", "normal": "value"},
+            {"password": "secret", "other": "value"}
+        ]
+        
+        expected = [
+            {"chargePointIdentity": "REDACTED", "normal": "value"},
+            {"password": "REDACTED", "other": "value"}
+        ]
+        
+        result = redact_sensitive_data(input_data)
+        self.assertEqual(result, expected)
+
+    def test_redact_sensitive_data_non_sensitive(self):
+        """Test that non-sensitive data is not affected"""
+        input_data = {
+            "type": "ocpp",
+            "address": "https://example.com",
+            "normal_field": "normal_value",
+            "another_field": 123
+        }
+        
+        expected = {
+            "type": "ocpp",
+            "address": "https://example.com",
+            "normal_field": "normal_value",
+            "another_field": 123
+        }
+        
+        result = redact_sensitive_data(input_data)
+        self.assertEqual(result, expected)
+
+    def test_redact_sensitive_data_case_insensitive(self):
+        """Test that field name matching is case-insensitive"""
+        input_data = {
+            "chargepointidentity": "secret1",
+            "ChargePointIdentity": "secret2",
+            "PASSWORD": "secret3",
+            "password": "secret4"
+        }
+        
+        expected = {
+            "chargepointidentity": "REDACTED",
+            "ChargePointIdentity": "REDACTED",
+            "PASSWORD": "REDACTED",
+            "password": "REDACTED"
+        }
+        
+        result = redact_sensitive_data(input_data)
+        self.assertEqual(result, expected)
+
+    def test_redact_sensitive_data_none_input(self):
+        """Test redacting None input"""
+        result = redact_sensitive_data(None)
+        self.assertIsNone(result)
+
+    def test_redact_sensitive_data_other_types(self):
+        """Test redacting other data types"""
+        self.assertEqual(redact_sensitive_data("string"), "string")
+        self.assertEqual(redact_sensitive_data(123), 123)
+        self.assertEqual(redact_sensitive_data(True), True)
+        self.assertEqual(redact_sensitive_data(3.14), 3.14)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ocpp_redaction.py
+++ b/tests/test_ocpp_redaction.py
@@ -1,5 +1,5 @@
 import unittest
-from src.evse_controller.utils.redaction import redact_sensitive_data
+from evse_controller.utils.redaction import redact_sensitive_data
 
 
 class TestOCPPRedaction(unittest.TestCase):


### PR DESCRIPTION
This should be a lot more reliable going forward. I've made the OCPP management asynchronous which means that if it doesn't work at one time, it can be re-tried. I've seen numerous examples of rate-limiting from the Wallbox API, and a good number of examples of working first time. So this code should increase the reliability and be somewhat resilient to future API changes as have happened in the past (cf the Wallbox API library we use).